### PR TITLE
fix: Error when CreateVMReq does not have Spec

### DIFF
--- a/infrastructure/grpc/server.go
+++ b/infrastructure/grpc/server.go
@@ -39,8 +39,8 @@ func (s *server) CreateMicroVM(
 	logger := log.GetLogger(ctx)
 	logger.Trace("converting request to model")
 
-	if req == nil {
-		logger.Error("invalid create microvm request")
+	if req == nil || req.Microvm == nil {
+		logger.Error("invalid create microvm request: MicroVMSpec required")
 
 		//nolint:wrapcheck // don't wrap grpc errors when using the status package
 		return nil, status.Error(codes.InvalidArgument, "invalid request")

--- a/infrastructure/grpc/server_test.go
+++ b/infrastructure/grpc/server_test.go
@@ -29,6 +29,12 @@ func TestServer_CreateMicroVM(t *testing.T) {
 			expect:      func(cm *mock.MockMicroVMCommandUseCasesMockRecorder, qm *mock.MockMicroVMQueryUseCasesMockRecorder) {},
 		},
 		{
+			name:        "nil spec should fail with error",
+			createReq:   &mvm1.CreateMicroVMRequest{},
+			expectError: true,
+			expect:      func(cm *mock.MockMicroVMCommandUseCasesMockRecorder, qm *mock.MockMicroVMQueryUseCasesMockRecorder) {},
+		},
+		{
 			name:        "missing id should fail with error",
 			createReq:   createTestCreateRequest("", ""),
 			expectError: true,


### PR DESCRIPTION
In the rare case that a user either:
- Sends the wrong request type to the server (ie uses BloomRPC to send a
  ListReq to a Create call)
- Does not include a Spec at all on a CreateMicroVMRequest

we check for its presence and error if not found.

We are doing something similar for other server requests, so this
completes it.

Closes #469 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
