### PR TITLE
patch: Provision flintlock from latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,18 @@ The table below shows you which versions of Firecracker are compatible with Flin
 
 | Flintlock         | Firecracker        |
 | ----------------- | ------------------ |
+| <= v0.1.0         | <= v0.25.2-macvtap |
 | <= v0.1.0-alpha.6 | <= v0.25.2-macvtap |
 |    v0.1.0-alpha.7 | **Do not use**     |
 |    v0.1.0-alpha.8 | <= v0.25.2-macvtap |
 
-> Note: Flintlock currently requires a custom build of Firecracker available [here](https://github.com/weaveworks/firecracker/releases).
+> Note: Flintlock currently requires a custom build of Firecracker available [here][fc-fork].
+
+> Note: Due to upstream development issues, Flintlock in future will only support
+Firecracker [`v0.25.2-macvtap`][fc-fork]. We will not maintain any versions beyond this.
+In future releases of Flintlock, Cloud Hypervisor will be the default and recommended
+MicroVM driver.
+
 ## License
 
 [MPL-2.0 License][license]
@@ -68,3 +75,4 @@ The table below shows you which versions of Firecracker are compatible with Flin
 [milestones]: https://github.com/weaveworks-liquidmetal/flintlock/milestones
 [adr]: ./docs/adr
 [license]: ./LICENSE
+[fc-fork]: https://github.com/weaveworks/firecracker/releases

--- a/hack/scripts/provision.sh
+++ b/hack/scripts/provision.sh
@@ -196,15 +196,6 @@ latest_release_tag() {
 	echo "$url"
 }
 
-# Returns the tag associated with a "latest" pre-release (pre-releases do not show
-# up in the API as used in the above latest_release_tag func)
-latest_pre_release_tag() {
-	local repo_name="$1"
-	tag=$(git ls-remote --tags --sort="v:refname" "https://github.com/$repo_name" |
-		tail -n 1 | sed 's/.*\///; s/\^{}//')
-	echo "$tag"
-}
-
 # Install the untarred binary attached to a release to /usr/local/bin
 install_release_bin() {
 	local download_url="$1"
@@ -294,7 +285,7 @@ install_flintlockd() {
 	say "Installing flintlockd version $tag to $INSTALL_PATH"
 
 	if [[ "$tag" == "$DEFAULT_VERSION" ]]; then
-		tag=$(latest_pre_release_tag "$FLINTLOCK_REPO")
+		tag=$(latest_release_tag "$FLINTLOCK_REPO")
 	fi
 
 	url=$(build_download_url "$FLINTLOCK_REPO" "$tag" "$FLINTLOCK_RELEASE_BIN")


### PR DESCRIPTION
Previously flintlock only had pre-releases, which meant a different
install method in `provision.sh`. Now it can use the standard func.

Also update the compatibility table and add a note about supported
Firecracker versions.
