### PR TITLE
feat: Add list all functionality

### DIFF
--- a/infrastructure/grpc/server.go
+++ b/infrastructure/grpc/server.go
@@ -147,7 +147,7 @@ func (s *server) ListMicroVMs(ctx context.Context,
 ) (*mvmv1.ListMicroVMsResponse, error) {
 	logger := log.GetLogger(ctx)
 
-	if req == nil || req.Namespace == "" {
+	if req == nil {
 		logger.Error("invalid get microvm request")
 
 		//nolint:wrapcheck // don't wrap grpc errors when using the status package

--- a/infrastructure/grpc/server_test.go
+++ b/infrastructure/grpc/server_test.go
@@ -267,10 +267,31 @@ func TestServer_ListMicroVMs(t *testing.T) {
 			expect:      func(cm *mock.MockMicroVMCommandUseCasesMockRecorder, qm *mock.MockMicroVMQueryUseCasesMockRecorder) {},
 		},
 		{
-			name:        "missing namespace should fail with error",
+			name:        "missing namespace should not fail with error",
 			listReq:     &mvm1.ListMicroVMsRequest{Namespace: ""},
-			expectError: true,
-			expect:      func(cm *mock.MockMicroVMCommandUseCasesMockRecorder, qm *mock.MockMicroVMQueryUseCasesMockRecorder) {},
+			expectError: false,
+			expect: func(cm *mock.MockMicroVMCommandUseCasesMockRecorder, qm *mock.MockMicroVMQueryUseCasesMockRecorder) {
+				qm.GetAllMicroVM(gomock.AssignableToTypeOf(
+					context.Background()),
+					gomock.Not(gomock.Eq("")),
+				).Return(
+					[]*models.MicroVM{
+						{
+							Version: 1,
+							Status: models.MicroVMStatus{
+								State: models.CreatedState,
+							},
+						},
+						{
+							Version: 1,
+							Status: models.MicroVMStatus{
+								State: models.CreatedState,
+							},
+						},
+					},
+					nil,
+				)
+			},
 		},
 		{
 			name:        "error from usecase should fail with error",


### PR DESCRIPTION
This removes the requirement that a call to GetAllMicroVM must have a
namespace argument in the request. We do filtering on the Repo, so it is
not harmful to have all params be optional.

If a call to GetAllMicroVM is made without namespace or name, then all
mvms on the host will be returned.

If a call to GetAllMicroVM is made with just name, then all mvms
matching that name in any namespace will be returned.

If a call to to GetAllMicroVM is made with just namespace, then all mvms
under that namespace will be returned.

We can consider RBAC implications when we get to that.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
