### PR TITLE
feat: add pprof to flintlock

### DIFF
--- a/internal/command/flags/flags.go
+++ b/internal/command/flags/flags.go
@@ -27,6 +27,7 @@ const (
 	tlsKeyFlag            = "tls-key"
 	tlsClientValidateFlag = "tls-client-validate"
 	tlsClientCAFlag       = "tls-client-ca"
+	debugEndpointFlag     = "debug-endpoint"
 )
 
 // AddGRPCServerFlagsToCommand will add gRPC server flags to the supplied command.
@@ -177,4 +178,11 @@ func AddContainerDFlagsToCommand(cmd *cobra.Command, cfg *config.Config) {
 		containerdNamespace,
 		defaults.ContainerdNamespace,
 		"The name of the containerd namespace to use.")
+}
+
+func AddDebugFlagsToCommand(cmd *cobra.Command, cfg *config.Config) {
+	cmd.Flags().StringVar(&cfg.DebugEndpoint,
+		debugEndpointFlag,
+		"",
+		"The endpoint for the debug web server to listen on. It must include a port (e.g. localhost:10500).  An empty string means disable the debug endpoint.")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,7 @@ type Config struct {
 	Logging log.Config
 	// GRPCEndpoint is the endpoint for the gRPC server.
 	GRPCAPIEndpoint string
-	// HTTPAPIEndpoint is the endpoint for the HTTP proxy for the gRPC service..
+	// HTTPAPIEndpoint is the endpoint for the HTTP proxy for the gRPC service
 	HTTPAPIEndpoint string
 	// FirecrackerBin is the firecracker binary to use.
 	FirecrackerBin string
@@ -46,6 +46,8 @@ type Config struct {
 	BasicAuthToken string
 	// TLS holds the TLS related configuration.
 	TLS TLSConfig
+	// DebugEndpoint is the endpoint for the debug web server. An empty string means disable the debug endpoint.
+	DebugEndpoint string
 }
 
 // TLSConfig holds the configuration for TLS.


### PR DESCRIPTION
**What this PR does / why we need it**:

This change adds the ability to make pprof available via http. By
default it won't be available. If you specify a debug endpoint via
`--debug-endpoint` then it will start a webserver listening at that
endpoint and pprof is available from there.

We decided to use an endpoint as that will allow users to only expose
the debug endpoint locally or via the network.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates #503 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
