### PR TITLE
feat: add support for Firecracker v1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,15 @@ Your feedback is always welcome!
 
 The table below shows you which versions of Firecracker are compatible with Flintlock:
 
-| Flintlock         | Firecracker        |
-| ----------------- | ------------------ |
-| <= v0.1.0         | <= v0.25.2-macvtap |
-| <= v0.1.0-alpha.6 | <= v0.25.2-macvtap |
-|    v0.1.0-alpha.7 | **Do not use**     |
-|    v0.1.0-alpha.8 | <= v0.25.2-macvtap |
+| Flintlock         | Firecracker                      |
+| ----------------- | -------------------------------- |
+|    v0.3.0         | Official v1.0+ or v1.0.0-macvtap |
+| <= v0.2.0         | <= v0.25.2-macvtap               |
+| <= v0.1.0-alpha.6 | <= v0.25.2-macvtap               |
+|    v0.1.0-alpha.7 | **Do not use**                   |
+|    v0.1.0-alpha.8 | <= v0.25.2-macvtap               |
 
-> Note: Flintlock currently requires a custom build of Firecracker available [here][fc-fork].
-
-> Note: Due to upstream development issues, Flintlock in future will only support
-Firecracker [`v0.25.2-macvtap`][fc-fork]. We will not maintain any versions beyond this.
-In future releases of Flintlock, Cloud Hypervisor will be the default and recommended
-MicroVM driver.
+> Note: Flintlock currently requires a custom build of Firecracker if you plan to use macvtap available [here][fc-fork].
 
 ## License
 

--- a/infrastructure/firecracker/types.go
+++ b/infrastructure/firecracker/types.go
@@ -1,27 +1,5 @@
 package firecracker
 
-const (
-	// CacheTypeUnsafe indovates the flushing mechanic will be advertised to
-	// the guest driver, but the operation will be a noop.
-	CacheTypeUnsafe CacheType = "Unsafe"
-	// CacheTypeWriteBack indicates the flushing mechanic will be advertised
-	// to the guest driver and flush requests coming from the guest will be
-	// performed using `fsync`.
-	CacheTypeWriteBack CacheType = "WriteBack"
-
-	LogLevelError   LogLevel = "Error"
-	LogLevelWarning LogLevel = "Warning"
-	LogLevelInfo    LogLevel = "Info"
-	LogLevelDebug   LogLevel = "Debug"
-
-	// InstanceStateNotStarted the instance hasn't started running yet.
-	InstanceStateNotStarted InstanceState = "Not started"
-	// InstanceStateRunning the instance is running.
-	InstanceStateRunning InstanceState = "Running"
-	// InstanceStatePaused the instance is currently paused.
-	InstanceStatePaused InstanceState = "Paused"
-)
-
 // VmmConfig contains the configuration of the microvm.
 // Based on the rust structure from firecracker:
 // https://github.com/firecracker-microvm/firecracker/blob/0690010524001b606f67c1a65c67f3c27883183f/src/vmm/src/resources.rs#L51.
@@ -39,7 +17,7 @@ type VmmConfig struct {
 	// Metrics is the metrics configuration.
 	Metrics *MetricsConfig `json:"metrics,omitempty"`
 	// Mmds is the configuration for the metadata service
-	Mmds *MMDSConfig `json:"MmdsConfig,omitempty"`
+	Mmds *MMDSConfig `json:"mmds-config,omitempty"`
 	// NetDevices is the configuration for the microvm network devices.
 	NetDevices []NetworkInterfaceConfig `json:"network-interfaces"`
 	// VsockDevice is the configuration for the vsock device.
@@ -51,8 +29,8 @@ type MachineConfig struct {
 	VcpuCount int64 `json:"vcpu_count"`
 	// MemSizeMib is the memory size in MiB.
 	MemSizeMib int64 `json:"mem_size_mib"`
-	// HTEnabled enables or disabled hyperthreading.
-	HTEnabled bool `json:"ht_enabled"`
+	// SMT enables or disabled hyperthreading.
+	SMT bool `json:"smt"`
 	// CPUTemplate is a CPU template that it is used to filter the CPU features exposed to the guest.
 	CPUTemplate *string `json:"cpu_template,omitempty"`
 	// TrackDirtyPages enables or disables dirty page tracking. Enabling allows incremental snapshots.
@@ -60,6 +38,25 @@ type MachineConfig struct {
 }
 
 type CacheType string
+
+const (
+	// CacheTypeUnsafe indovates the flushing mechanic will be advertised to
+	// the guest driver, but the operation will be a noop.
+	CacheTypeUnsafe CacheType = "Unsafe"
+	// CacheTypeWriteBack indicates the flushing mechanic will be advertised
+	// to the guest driver and flush requests coming from the guest will be
+	// performed using `fsync`.
+	CacheTypeWriteBack CacheType = "WriteBack"
+)
+
+type FileEngineType string
+
+const (
+	// FileEngineTypeSync specifies using a synchronous engine based on blocking system calls.
+	FileEngineTypeSync = FileEngineType("Sync")
+	// FileEngineTypeAsync specifies using a asynchronous engine based on io_uring.
+	FileEngineTypeAsync = FileEngineType("Async")
+)
 
 // BlockDeviceConfig contains the configuration for a microvm block device.
 type BlockDeviceConfig struct {
@@ -103,12 +100,6 @@ type NetworkInterfaceConfig struct {
 	HostDevName string `json:"host_dev_name"`
 	// GuestMAC is the mac address to use.
 	GuestMAC string `json:"guest_mac,omitempty"`
-	// AllowMMDSRequests is true the device model will reply to HTTP GET
-	// requests sent to the MMDS address via this interface. In this case,
-	// both ARP requests for `169.254.169.254` and TCP segments heading to the
-	// same address are intercepted by the device model, and do not reach
-	// the associated TAP device.
-	AllowMMDSRequests bool `json:"allow_mmds_requests"`
 	// RxRateLimiter is the rate limiter for received packages.
 	// RxRateLimiter *RateLimiterConfig `json:"rx_rate_limiter,omitempty"`
 	// TxRateLimiter is the rate limiter for transmitted packages.
@@ -116,6 +107,13 @@ type NetworkInterfaceConfig struct {
 }
 
 type LogLevel string
+
+const (
+	LogLevelError   LogLevel = "Error"
+	LogLevelWarning LogLevel = "Warning"
+	LogLevelInfo    LogLevel = "Info"
+	LogLevelDebug   LogLevel = "Debug"
+)
 
 // LoggerConfig holds the configuration for the logger.
 type LoggerConfig struct {
@@ -145,8 +143,19 @@ type MetricsConfig struct {
 	Path string `json:"metrics_path"`
 }
 
+type MMDSVersion string
+
+const (
+	MMDSVersion1 = MMDSVersion("V1")
+	MMDSVersion2 = MMDSVersion("V2")
+)
+
 // MMDSConfig is the config related to the mmds.
 type MMDSConfig struct {
+	// Version specifies the MMDS version to use. If not specified it will default to V1. Supported values are V1 & V2.
+	Version MMDSVersion `json:"version,omitempty"`
+	// NetworkInterfaces specifies the interfaces that allow forwarding packets to MMDS.
+	NetworkInterfaces []string `json:"network_interfaces,omitempty"`
 	// IPV4Address is the MMDS IPv4 configured address.
 	IPV4Address *string `json:"ipv4_address,omitempty"`
 }
@@ -167,3 +176,12 @@ type Metadata struct {
 
 // InstanceState is a type that represents the running state of a Firecracker instance.
 type InstanceState string
+
+const (
+	// InstanceStateNotStarted the instance hasn't started running yet.
+	InstanceStateNotStarted InstanceState = "Not started"
+	// InstanceStateRunning the instance is running.
+	InstanceStateRunning InstanceState = "Running"
+	// InstanceStatePaused the instance is currently paused.
+	InstanceStatePaused InstanceState = "Paused"
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

A few changes to support Firecracker v1+. We are sticking
with the v1 MMDS initially and will look to upgrade to the v2 MMDS in
the future.

To use this version with macvtap we will need to use our fork with the
1.1 changes.

NOTE: incorrect serialization caused the issues with MMDS not working.
Strangely Firecracker didn't complain about the invalid json config.
Time and stress wasted on what was essentially a typo. ffs.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #390 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
