### PR TITLE
chore: remove pinning of the firecracker version

### DIFF
--- a/test/tools/config/userdata.sh
+++ b/test/tools/config/userdata.sh
@@ -52,7 +52,7 @@ if [[ -z "$SKIP_DIRECT_LVM" ]]; then
 fi
 
 # install latest firecracker
-./flintlock/hack/scripts/provision.sh firecracker --version v0.25.2-macvtap
+./flintlock/hack/scripts/provision.sh firecracker
 
 # install and setup containerd
 # curl -sL https://api.github.com/repos/containerd/containerd/releases/latest 2>/dev/null |


### PR DESCRIPTION
**What this PR does / why we need it**:

With adding support for Firecracker v1.0+ we need remove pinning to the
old version of our fork.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
