### PR TITLE
feat: force dhcp to use mac as client identifier

### DIFF
--- a/client/cloudinit/network/network.go
+++ b/client/cloudinit/network/network.go
@@ -1,18 +1,23 @@
 package network
 
+const (
+	DhcpIdentifierMac = "mac"
+)
+
 type Network struct {
 	Version  int                 `yaml:"version"`
 	Ethernet map[string]Ethernet `yaml:"ethernets"`
 }
 
 type Ethernet struct {
-	Match       Match       `yaml:"match"`
-	Addresses   []string    `yaml:"addresses,omitempty"`
-	GatewayIPv4 string      `yaml:"gateway4,omitempty"`
-	GatewayIPv6 string      `yaml:"gateway6,omitempty"`
-	DHCP4       *bool       `yaml:"dhcp4,omitempty"`
-	DHCP6       *bool       `yaml:"dhcp6,omitempty"`
-	Nameservers Nameservers `yaml:"nameservers,omitempty"`
+	Match          Match       `yaml:"match"`
+	Addresses      []string    `yaml:"addresses,omitempty"`
+	GatewayIPv4    string      `yaml:"gateway4,omitempty"`
+	GatewayIPv6    string      `yaml:"gateway6,omitempty"`
+	DHCP4          *bool       `yaml:"dhcp4,omitempty"`
+	DHCP6          *bool       `yaml:"dhcp6,omitempty"`
+	DHCPIdentifier *string     `yaml:"dhcp-identifier,omitempty"`
+	Nameservers    Nameservers `yaml:"nameservers,omitempty"`
 }
 
 type Match struct {

--- a/infrastructure/firecracker/config.go
+++ b/infrastructure/firecracker/config.go
@@ -217,9 +217,10 @@ func generateNetworkConfig(vm *models.MicroVM) (string, error) {
 		macAddress := getMacAddress(&iface, status)
 
 		eth := &cinetwork.Ethernet{
-			Match: cinetwork.Match{},
-			DHCP4: firecracker.Bool(true),
-			DHCP6: firecracker.Bool(true),
+			Match:          cinetwork.Match{},
+			DHCP4:          firecracker.Bool(true),
+			DHCP6:          firecracker.Bool(true),
+			DHCPIdentifier: firecracker.String(cinetwork.DhcpIdentifierMac),
 		}
 
 		if macAddress != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

This change will force DHCP to use the mac address as the client
identifier when requesting a mac address. Without this (depending on
your distro) it may not use a mac address and the mv may not get a ip
address assigned to it.

Signed-off-by: Richard Case <richard.case@outlook.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #518 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
