### PR TITLE
refactor: moved resync to controller

### DIFF
--- a/core/application/reconcile.go
+++ b/core/application/reconcile.go
@@ -35,28 +35,6 @@ func (a *app) ReconcileMicroVM(ctx context.Context, vmid models.VMID) error {
 	return a.reconcile(ctx, spec, logger)
 }
 
-func (a *app) ResyncMicroVMs(ctx context.Context, namespace string) error {
-	logger := log.GetLogger(ctx).WithFields(logrus.Fields{
-		"action":    "resync",
-		"namespace": "ns",
-	})
-	logger.Info("Resyncing specs")
-	logger.Debug("Getting all specs")
-
-	specs, err := a.ports.Repo.GetAll(ctx, models.ListMicroVMQuery{"namespace": namespace})
-	if err != nil {
-		return fmt.Errorf("getting all microvm specs for resync: %w", err)
-	}
-
-	for _, spec := range specs {
-		if err := a.reconcile(ctx, spec, logger); err != nil {
-			return fmt.Errorf("resync reconcile for spec %s: %w", spec.ID, err)
-		}
-	}
-
-	return nil
-}
-
 func (a *app) plan(spec *models.MicroVM, logger *logrus.Entry) planner.Plan {
 	l := logger.WithField("stage", "plan")
 	l.Info("Generate plan")

--- a/core/ports/usecases.go
+++ b/core/ports/usecases.go
@@ -26,7 +26,4 @@ type MicroVMQueryUseCases interface {
 type ReconcileMicroVMsUseCase interface {
 	// ReconcileMicroVM is a use case for reconciling a specific microvm.
 	ReconcileMicroVM(ctx context.Context, vmid models.VMID) error
-	// ResyncMicroVMs is used to resync the microvms. If a namespace is supplied then it will
-	// resync only the microvms in that namespaces.
-	ResyncMicroVMs(ctx context.Context, namespace string) error
 }

--- a/infrastructure/controllers/microvm_controller_test.go
+++ b/infrastructure/controllers/microvm_controller_test.go
@@ -120,13 +120,14 @@ func TestMicroVMController(t *testing.T) {
 
 			em := mock.NewMockEventService(mockCtrl)
 			uc := mock.NewMockReconcileMicroVMsUseCase(mockCtrl)
+			quc := mock.NewMockMicroVMQueryUseCases(mockCtrl)
 
 			evtCh := make(chan *ports.EventEnvelope)
 			evtErrCh := make(chan error, 1)
 
 			tc.expect(em.EXPECT(), uc.EXPECT(), evtCh, evtErrCh)
 
-			controller := controllers.New(em, uc)
+			controller := controllers.New(em, uc, quc)
 
 			ctrlWG := sync.WaitGroup{}
 			ctrlWG.Add(1)

--- a/internal/inject/wire.go
+++ b/internal/inject/wire.go
@@ -47,7 +47,7 @@ func InitializeApp(cfg *config.Config, ports *ports.Collection) application.App 
 }
 
 func InializeController(app application.App, ports *ports.Collection) *controllers.MicroVMController {
-	wire.Build(controllers.New, eventSvcFromScope, reconcileUCFromApp)
+	wire.Build(controllers.New, eventSvcFromScope, reconcileUCFromApp, queryUCFromApp)
 
 	return nil
 }

--- a/internal/inject/wire_gen.go
+++ b/internal/inject/wire_gen.go
@@ -59,7 +59,8 @@ func InitializeApp(cfg *config.Config, ports2 *ports.Collection) application.App
 func InializeController(app application.App, ports2 *ports.Collection) *controllers.MicroVMController {
 	eventService := eventSvcFromScope(ports2)
 	reconcileMicroVMsUseCase := reconcileUCFromApp(app)
-	microVMController := controllers.New(eventService, reconcileMicroVMsUseCase)
+	microVMQueryUseCases := queryUCFromApp(app)
+	microVMController := controllers.New(eventService, reconcileMicroVMsUseCase, microVMQueryUseCases)
 	return microVMController
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The resynce functionality has been moved to the controller. This means
the core application know how to do CRUD on the vmspecs and how to
reconcile a single vm spec.

Functionality such as resynce can be orchestrated via calls to the core
app.

Signed-off-by: Richard Case <richard.case@outlook.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #520 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
