### PR TITLE
Curl scripts to make Vagrantfile self-contained

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,8 +83,12 @@ EOF
     SHELL
   end
 
-  config.vm.provision "configure-thinpool", type: "shell",
-    run: "once", path: "./hack/scripts/devpool.sh"
+  config.vm.provision "configure-thinpool", type: "shell", run: "once" do |sh|
+    sh.inline = <<~SHELL
+    curl -fsSL "https://raw.githubusercontent.com/weaveworks-liquidmetal/flintlock/main/hack/scripts/devpool.sh" -o /tmp/devpool.sh
+    chmod +x /tmp/devpool.sh && /tmp/devpool.sh
+    SHELL
+  end
 
   config.vm.provision "configure-containerd", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
@@ -96,7 +100,7 @@ EOF
       mkdir -p /var/lib/containerd-dev/snapshotter/devmapper
       mkdir -p /run/containerd-dev/
 
-      cp /home/vagrant/flintlock/hack/scripts/example-config.toml /etc/containerd/config.toml
+      curl -fsSL "https://raw.githubusercontent.com/weaveworks-liquidmetal/flintlock/main/hack/scripts/example-config.toml" -o /etc/containerd/config.toml
 
       systemctl restart containerd
     SHELL


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
Previously, using the Vagrantfile required cloning the Flintlock repo because it was reading `scripts/devpool.sh` and `scripts/example-config.toml` from a local path. Now, it curls these scripts so that the Vagrantfile can be used independently from the repo. :)

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
