### PR TITLE
fix: Edit service file to wait on containerd

### DIFF
--- a/hack/scripts/provision.sh
+++ b/hack/scripts/provision.sh
@@ -375,6 +375,10 @@ start_flintlockd_service() {
 
 	service=$(basename "$FLINTLOCKD_SERVICE_FILE")
 	fetch_service_file "$FLINTLOCK_REPO" "$service" "$FLINTLOCKD_SERVICE_FILE"
+
+	containerd_service=$(basename "$CONTAINERD_SERVICE_FILE")
+	sed -i "s|\(Requires=\)\(.*\)|\1$containerd_service|" "$FLINTLOCKD_SERVICE_FILE"
+
 	start_service "$FLINTLOCK_BIN"
 }
 


### PR DESCRIPTION
Flintlock depends on containerd so it should wait for it to become available and stop when the containerd service stops.
In a dev environment, the containerd service may be running under another name, so flintlock should watch the correct one.