### PR TITLE
Rename docs deploy key

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -33,7 +33,7 @@ jobs:
           go-version: '1.18'
       - uses: webfactory/ssh-agent@v0.5.0
         with:
-          ssh-private-key: ${{ secrets.FLINTLOCK_DOCS_WEAVEWORKS_DOCS_BOT_DEPLOY_KEY }}
+          ssh-private-key: ${{ secrets.BOT_DEPLOY_KEY }}
       - name: Release to GitHub Pages
         env:
           USE_SSH: true


### PR DESCRIPTION
I don't know why github didn't want to see the old one, even when I
replaced it.
Now with the same key under a new name it is fine so.... yeh.
