### PR TITLE
fix: Publish docs under github.io domain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -577,7 +577,7 @@ Contributors are also welcome to backfill ADRs if they are found to be missing.
 
 # :rocket: :tada: Thanks for reading! :tada: :rocket:
 
-[user-docs]: https://docs.flintlock.dev/
+[user-docs]: https://weaveworks-liquidmetal.github.io/flintlock/
 [slack-channel]: https://weave-community.slack.com/archives/C02KARWGR7S
 [quick-start]: ./docs/quick-start.md
 [discussions]: https://github.com/weaveworks-liquidmetal/flintlock/discussions

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The table below shows you which versions of Firecracker are compatible with Flin
 
 [MPL-2.0 License][license]
 
-[quickstart]: https://docs.flintlock.dev/docs/category/getting-started
+[quickstart]: https://weaveworks-liquidmetal.github.io/flintlock/docs/category/getting-started/
 [contrib]: ./CONTRIBUTING.md
 [coc]: ./CODE_OF_CONDUCT.md
 [issues]: https://github.com/weaveworks-liquidmetal/flintlock/issues

--- a/docs/image-creation.md
+++ b/docs/image-creation.md
@@ -2,4 +2,4 @@
 
 This doc has been superseded by the [published docs][site].
 
-[site]: https://docs.flintlock.dev/docs/guides/images
+[site]: https://weaveworks-liquidmetal.github.io/flintlock/docs/guides/images

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -2,4 +2,4 @@
 
 This doc has been superseded by the [published docs][site].
 
-[site]: https://docs.flintlock.dev/
+[site]: https://weaveworks-liquidmetal.github.io/flintlock/

--- a/flintlockd.service
+++ b/flintlockd.service
@@ -14,7 +14,7 @@
 
 [Unit]
 Description=flintlock microvm service
-Documentation=https://docs.flintlock.dev/
+Documentation=https://weaveworks-liquidmetal.github.io/flintlock/
 Requires=containerd.service
 
 [Service]

--- a/userdocs/docusaurus.config.js
+++ b/userdocs/docusaurus.config.js
@@ -8,14 +8,14 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'Flintlock',
   tagline: ' Lock, Stock, and Two Smoking MicroVMs. Create and manage the lifecycle of MicroVMs backed by containerd.',
-  url: 'https://docs.flintlock.dev/',
-  baseUrl: '/',
+  url: 'https://weaveworks-liquidmetal.github.io',
+  baseUrl: '/flintlock/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
-  organizationName: 'weaveworks',
+  organizationName: 'weaveworks-liquidmetal',
   projectName: 'flintlock',
-  trailingSlash: false,
+  trailingSlash: true,
 
   presets: [
     [


### PR DESCRIPTION
The old domain is broken for a time