### PR TITLE
Run the integration tests once a week

### DIFF
--- a/.github/workflows/nightly_e2e.yml
+++ b/.github/workflows/nightly_e2e.yml
@@ -3,7 +3,7 @@ name: nightly_e2e
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 
 jobs:
   e2e:


### PR DESCRIPTION
While the team is not working full-time, we can save some $$ by only running once a week. This can be reverted once the codebase is being changed regularly again.