### PR TITLE
move notification to #liquid-metal-dev from #team-quick-silver

### DIFF
--- a/.github/workflows/fork.yaml
+++ b/.github/workflows/fork.yaml
@@ -68,7 +68,7 @@ jobs:
       with:
         slack_token: ${{ secrets.SLACK_TOKEN }}
         message: "There is a new version of Firecracker, complete the todo list here: <https://github.com/weaveworks-liquidmetal/flintlock/issues/${{ steps.issue.outputs.issue-number }}|#${{ steps.issue.outputs.issue-number }}>."
-        channel: team-quick-silver
+        channel: liquid-metal-dev
         color: green
         verbose: false
   notify:
@@ -81,6 +81,6 @@ jobs:
       with:
         slack_token: ${{ secrets.SLACK_TOKEN }}
         message: "There is a new firecracker version, but the 'Bump Firecracker' issue failed :sad-parrot: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Click here>."
-        channel: team-quick-silver
+        channel: liquid-metal-dev
         color: red
         verbose: false

--- a/.github/workflows/nightly_e2e.yml
+++ b/.github/workflows/nightly_e2e.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         slack_token: ${{ secrets.SLACK_TOKEN }}
         message: "A flintlock integration test run failed :sad-parrot: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Click here> and weep."
-        channel: team-quick-silver
+        channel: liquid-metal-dev
         color: red
         verbose: false
 
@@ -49,7 +49,7 @@ jobs:
       with:
         slack_token: ${{ secrets.SLACK_TOKEN }}
         message: "A flintlock integration test run succeeded :party-gopher:"
-        channel: team-quick-silver
+        channel: liquid-metal-dev
         color: green
         verbose: false
 


### PR DESCRIPTION
The mentioned channel was archived.

[Potentially in the future](https://github.com/weaveworks-liquidmetal/flintlock/issues/730) we can redirect it to the the [community channel](https://weave-community.slack.com/archives/C02KARWGR7S), but that would require changes to the secret and it's easier to just change to that channel for now.